### PR TITLE
Updated Starting Class Logic

### DIFF
--- a/dependencies/SoulsFormats/SoulsFormats/Formats/DCX.cs
+++ b/dependencies/SoulsFormats/SoulsFormats/Formats/DCX.cs
@@ -714,7 +714,7 @@ namespace SoulsFormats
         private static void CompressDCXZSTD(byte[] data, BinaryWriterEx bw, int compressionLevel = 5)
         {
             byte[] compressed = SFUtil.WriteZstd(data, compressionLevel);
-            //TODO revise implementation
+            //TODO revise implementation, currently doesn't seem to work
             bw.WriteASCII("DCX\0");
             bw.WriteInt32(0x11000);
             bw.WriteInt32(0x18);

--- a/dependencies/SoulsFormats/SoulsFormats/Formats/HKX/HKX.cs
+++ b/dependencies/SoulsFormats/SoulsFormats/Formats/HKX/HKX.cs
@@ -822,8 +822,7 @@ namespace SoulsFormats
                     {
                         var reference = dest.Reference;
                         reference.DestLocalOffset = dest.Dst - SectionOffset;
-                        // todo: see why this turns ds1 parent bone indices into hkaAnimation
-                        // and remove this horrible "solution"
+                        // see why this turns ds1 parent bone indices into hkaAnimation and remove this horrible "solution"
                         if (!(hkx.Variation == HKXVariation.HKXDS1 && this is HKASkeleton))
                             reference.DestObject = this;
                     }

--- a/src/ERBingoRandomizer/Settings/Equipment.cs
+++ b/src/ERBingoRandomizer/Settings/Equipment.cs
@@ -2,9 +2,8 @@ using System.Collections.Generic;
 
 namespace Project.Settings;
 
-public static class Equipment
+public class Equipment
 {   // TODO make into an initialization method for repeat randomizer calls
-    // WEAPONS
     public static List<int> RemembranceWeaponIDs = new List<int>()
     {
         3500000, 17500000, 23510000, 67520000, 18510000, 4530000, 4550000, 3510000,
@@ -213,6 +212,21 @@ public static class Equipment
         2004910, 2005000, 2006200, 2006210,
         2007410, 2007420,
     };
+    public static List<int> StartingSorceryIDs = new List<int>()
+    {
+        4000, 4010, 4040, 4460, 4470, 4660, 4070, 4390, 4440, 6500,
+        4100, 4140, 4370, 4400, 4490, 4001, 4670, 5000, 4480, 4640,
+        4720, 4090, 4610, 4630, 4710,
+        // 2004500,
+    };
+    public static List<int> StartingIncantationIDs = new List<int>()
+    {
+        6000, 6420, 6820, 6220, 6850, 6010, 6460, 6510, 6800, 7230,
+        7200, 7210, 6040, 6320, 6400, 6421, 6840, 7220, 6030, 6300,
+        6520, 6700, 6770, 6810, 7010, 6050, 6422, 6830, 6960, 7000,
+        7020, 7030, 7040, 6001, 7310,
+        // 2006800, 2007800
+    };
     public static List<int> StartingWeaponIDs = new List<int>()
     {   // TODO non-exhaustive list of weapons. Until level calc is working again a smaller list of weapons that are more likely to be equippable
         // DLC
@@ -235,6 +249,21 @@ public static class Equipment
         11000000, 11010000, 11030000, 11040000, 11050000, 11060000, 11070000, 11080000, 11090000,
         11100000, 11110000, 11120000, 11130000, 16000000, 16050000, 16140000, 16030000, 16080000,
         9000000, 9030000, 9040000, 9060000, 9070000, 9080000,
+    };
+    public static IReadOnlyList<List<int>> SideWeaponLists = new List<List<int>>()
+    {
+        TorchIDs,
+        GreatShieldIDs,
+        MediumShieldIDs,
+        SmallShieldIDs,
+        DaggerIDs,
+        ClawIDs,
+        FistIDs,
+        ThrustingSwordIDs,
+        WhipIDs,
+        PerfumeBottleIDs,
+        LightBowAndBowIDs,
+        BallistaOrGreatBowIDs,
     };
     public static List<int> SideWeaponIDs = new List<int>()
     {

--- a/src/ERBingoRandomizer/Tasks/Randomizer.Equipment.cs
+++ b/src/ERBingoRandomizer/Tasks/Randomizer.Equipment.cs
@@ -1,16 +1,19 @@
 ﻿using Project.Params;
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Linq;
 using Project.Settings;
 using FSParam;
+using Project.Utility;
 
 namespace Project.Tasks;
 
 public partial class Randomizer
 {
-    private int randomizeStartingWeapon(int id, IReadOnlyList<int> weapons)
+    private int randomizeStartingWeapon(int id, List<int> weapons)
     { // TODO Rely on weapons table
+        weapons.Shuffle(_random);
         int limit = weapons.Count;
         int newID = weapons[_random.Next(limit)];
         // while (!_weaponDictionary.ContainsKey(newID))
@@ -25,7 +28,8 @@ public partial class Randomizer
     }
     private int getRandomArmor(int id, byte type, IReadOnlyDictionary<byte, List<int>> gearLists)
     {
-        IReadOnlyList<int> armors = gearLists[type];
+        List<int> armors = gearLists[type];
+        armors.Shuffle(_random);
         return armors[_random.Next(armors.Count)];
     }
     private bool validateNoItem(int id, int chance)
@@ -98,25 +102,29 @@ public partial class Randomizer
     private void randomizeSorceries(CharaInitParam chr, IReadOnlyList<int> spells)
     {
         assignUsableWeapon(chr, Const.StaffType);
-        chr.equipSpell01 = assignStartingSpell(chr, Const.SorceryType, spells);
+        chr.equipSpell01 = assignStartingSpell(chr, Const.SorceryType, Equipment.StartingSorceryIDs);
     }
     private void randomizeIncantations(CharaInitParam chr, IReadOnlyList<int> spells)
     {
         assignUsableWeapon(chr, Const.SealType);
-        chr.equipSpell02 = assignStartingSpell(chr, Const.IncantationType, spells);
+        chr.equipSpell02 = assignStartingSpell(chr, Const.IncantationType, Equipment.StartingIncantationIDs);
     }
     private int assignStartingSpell(CharaInitParam chr, byte type, IReadOnlyList<int> spells)
     {
-        IReadOnlyList<Param.Row> table = _magicTypeDictionary[type];
-        while (true) // TODO refactor to not be a while (true)
-        {
-            int i = _random.Next() % table.Count;
-            Magic entry = _magicDictionary[table[i].ID];
-            if (chrCanUseSpell(entry, chr) && spells.Contains(table[i].ID))
-            {
-                return table[i].ID;
-            }
-        }
+        // if cannot be equipped pop spell off of list (make stack instead)
+        // TODO use while to debugging cancel button
+        // IReadOnlyList<Param.Row> table = _magicTypeDictionary[type];
+        // int index = _random.Next(table.Count);
+        // Magic entry = _magicDictionary[table[index].ID];
+
+        // while (!chrCanUseSpell(entry, chr))
+        // {
+        //     index = _random.Next(table.Count);
+        //     entry = _magicDictionary[table[index].ID];
+        // }
+        // return table[index].ID;
+        int index = _random.Next(spells.Count);
+        return spells[index];
     }
 
     private void assignUsableWeapon(CharaInitParam chr, ushort type)
@@ -172,7 +180,7 @@ public partial class Randomizer
         }
         return table[i].ID;
     }
-    private void randomizeEquipment(CharaInitParam chr, IReadOnlyList<int> main, IReadOnlyList<int> side)
+    private void randomizeEquipment(CharaInitParam chr, List<int> main, List<int> side)
     {
         chr.wepleft = randomizeStartingWeapon(chr.wepleft, side);
         chr.wepRight = randomizeStartingWeapon(chr.wepRight, main);

--- a/src/ERBingoRandomizer/Tasks/Randomizer.Helpers.cs
+++ b/src/ERBingoRandomizer/Tasks/Randomizer.Helpers.cs
@@ -9,6 +9,8 @@ using System.Collections.Specialized;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace Project.Tasks;
 
@@ -18,8 +20,10 @@ public partial class Randomizer
     {
         return "s" + Random.Shared.NextInt64().ToString() + "d";
     }
-    private static int getSeedFromHashData(IEnumerable<byte> hashData)
+    private static int hashStringToInteger(string input)
     {   // TODO visit why "toastx" breaks the app
+        byte[] array = Encoding.UTF8.GetBytes(input);
+        byte[] hashData = SHA256.HashData(array);
         IEnumerable<byte[]> chunks = hashData.Chunk(4);
         return chunks.Aggregate(0, (current, chunk) => current ^ BitConverter.ToInt32(chunk));
     }
@@ -181,7 +185,7 @@ public partial class Randomizer
         copyShopLineupParam(lot, newRemembrance);
     }
     private void addDescriptionString(CharaInitParam chr, int id)
-    { // TODO not updating in 1.12, fix
+    { // TODO not updating in 1.12, fix DLC weapon params are never read
         // List<string> str = new() {
         //     $"{_weaponNameDictionary[chr.wepleft]}{getRequiredLevelsWeapon(chr, chr.wepleft)}",
         //     $"{_weaponNameDictionary[chr.wepRight]}{getRequiredLevelsWeapon(chr, chr.wepRight)}",

--- a/src/ERBingoRandomizer/Tasks/Randomizer.Init.cs
+++ b/src/ERBingoRandomizer/Tasks/Randomizer.Init.cs
@@ -34,9 +34,10 @@ public partial class Randomizer
         _path = Path.GetDirectoryName(path) ?? throw new InvalidOperationException("Path.GetDirectoryName(path) was null. Incorrect path provided.");
         _regulationPath = $"{_path}/{Const.RegulationName}";
         _seed = string.IsNullOrWhiteSpace(seed) ? createSeed() : seed.Trim();
-        byte[] array = Encoding.UTF8.GetBytes(_seed);
-        byte[] hashData = SHA256.HashData(array);
-        int sequence = getSeedFromHashData(hashData);
+        // byte[] array = Encoding.UTF8.GetBytes(_seed);
+        // byte[] hashData = SHA256.HashData(array);
+        // int sequence = getSeedFromHashData(hashData);
+        int sequence = hashStringToInteger(_seed);
         _random = new Random(sequence);
         _cancellationToken = cancellationToken;
     }

--- a/src/ERBingoRandomizer/Tasks/Randomizer.Regulation.cs
+++ b/src/ERBingoRandomizer/Tasks/Randomizer.Regulation.cs
@@ -80,7 +80,6 @@ public partial class Randomizer
         logItem("Class Randomization - All items are randomized, classes with missing armor have a chance to gain armor.");
         logItem("Spells given to a class meet min stat requirements, and their will be a catalyst to cast.");
         logItem("If a class has a ranged weapon, appropriate ammunition will be allocated.\n");
-        // TODO get IDs of new DLC Powers of Remembrance "Rembrance Items"
 
         List<Param.Row> staves = _weaponTypeDictionary[Const.StaffType];
         List<Param.Row> seals = _weaponTypeDictionary[Const.SealType];
@@ -99,10 +98,14 @@ public partial class Randomizer
             if (row == null)
             { continue; }
 
+            int index = _random.Next(Equipment.SideWeaponLists.Count);
+            List<int> sideArms = Equipment.SideWeaponLists[index];
+            List<int> main = Equipment.StartingWeaponIDs;
+
             CharaInitParam startingClass = new(row);
-            randomizeEquipment(startingClass, Equipment.StartingWeaponIDs, Equipment.SideWeaponIDs);
+            randomizeEquipment(startingClass, main, sideArms);
             allocateStatsAndSpells(row.ID, startingClass, spells);
-            logCharaInitEntry(startingClass, i + 288100);
+            logCharaInitEntry(startingClass, i + 288100); // TODO update config
             addDescriptionString(startingClass, Const.ChrInfoMapping[i]);
         }
     }


### PR DESCRIPTION
added shuffle methods to starting class list, random integers are drawn from numbers less than 100 decreases chance that seeds will feel repetitive.

added starting sorceries and incants lists. Used to draw from a smaller, more likely to be usable spell list. Decreases iterations while loop needs to run, avoids randomizer freezing when 80% of incantations are unusable.