### PR TITLE
Starting Class Allocation: bug fixes

### DIFF
--- a/src/ERBingoRandomizer/FileHandler/BHD5Reader.cs
+++ b/src/ERBingoRandomizer/FileHandler/BHD5Reader.cs
@@ -62,7 +62,6 @@ public class BHD5Reader
         BHD5 dlc00 = readBHD5(msbBytes[1]);
         _data0 = new BHDInfo(data0, $"{path}/{Data0}");
         _dataDLC = new BHDInfo(dlc00, $"{path}/{DataDLC}");
-        // cancellationToken.ThrowIfCancellationRequested();
 
         if (cache && !cacheExists)
         {

--- a/src/ERBingoRandomizer/Tasks/Randomizer.Equipment.cs
+++ b/src/ERBingoRandomizer/Tasks/Randomizer.Equipment.cs
@@ -11,33 +11,48 @@ namespace Project.Tasks;
 
 public partial class Randomizer
 {
+    HashSet<int> allocatedIDs = new HashSet<int>();
     private int randomizeStartingWeapon(int id, List<int> weapons)
     { // TODO Rely on weapons table
         int limit = weapons.Count;
-        int newID = weapons[_random.Next(limit)];
+        int newID = 0;
+        int index = 0;
+        do
+        {
+            _cancellationToken.ThrowIfCancellationRequested();
+            index = _random.Next(limit);
+            newID = weapons[index];
+        } while (allocatedIDs.Contains(newID));
         // while (!_weaponDictionary.ContainsKey(newID))
         // { // TODO update _weaponDictionary for DLC weapons
         //     newID = weapons[_random.Next(limit)];
         // }
+        allocatedIDs.Add(newID);
         return washWeaponMetadata(newID);
-    }
-    private int exchangeArmorPiece(int id, byte type)
-    {
-        return getRandomArmor(id, type, Equipment.ArmorLists);
     }
     private int getRandomArmor(int id, byte type, IReadOnlyDictionary<byte, List<int>> gearLists)
     {
         List<int> armors = gearLists[type];
-        return armors[_random.Next(armors.Count)];
+        int limit = armors.Count;
+        int newID = 0;
+        int index = 0;
+        do
+        {
+            _cancellationToken.ThrowIfCancellationRequested();
+            index = _random.Next(limit);
+            newID = armors[index];
+        } while (allocatedIDs.Contains(newID));
+        allocatedIDs.Add(newID);
+        return newID;
     }
+    private int exchangeArmorPiece(int id, byte type) { return getRandomArmor(id, type, Equipment.ArmorLists); }
     private bool validateNoItem(int id, int chance)
     {   // currently never used, but could be handy in a chaos mode where classes start with potentially nothing
         int randomChance = _random.Next(chance);
 
         if (id == Const.NoItem)
-        {
-            return Config.Target < randomChance;
-        }
+        { return Config.Target < randomChance; }
+
         return false;
     }
     private bool hasWeaponOfType(CharaInitParam chr, params ushort[] types)
@@ -109,20 +124,6 @@ public partial class Randomizer
     }
     private int assignStartingSpell(CharaInitParam chr, byte type, IReadOnlyList<int> spells)
     {
-        //   if cannot be equipped pop spell off of list(make stack instead)
-        //   TODO use while to debugging cancel button
-
-        // IReadOnlyList<Param.Row> table = _magicTypeDictionary[type];
-        // int index = _random.Next(table.Count);
-        // Magic entry = _magicDictionary[table[index].ID];
-
-        // while (!chrCanUseSpell(entry, chr))
-        // {
-        //     index = _random.Next(table.Count);
-        //     entry = _magicDictionary[table[index].ID];
-        //     _cancellationToken.ThrowIfCancellationRequested();
-        // }
-        // return table[index].ID;
         int index = _random.Next(spells.Count);
         return spells[index];
     }
@@ -203,27 +204,23 @@ public partial class Randomizer
         chr.equipArrow = Const.NoItem;
         chr.arrowNum = ushort.MaxValue;
         if (hasWeaponOfType(chr, Const.BowType, Const.LightBowType))
-        {
-            giveArrows(chr);
-        }
+        { giveArrows(chr); }
+
         chr.equipSubArrow = Const.NoItem;
         chr.subArrowNum = ushort.MaxValue;
         if (hasWeaponOfType(chr, Const.GreatbowType))
-        {
-            giveGreatArrows(chr);
-        }
+        { giveGreatArrows(chr); }
+
         chr.equipBolt = Const.NoItem;
         chr.boltNum = ushort.MaxValue;
         if (hasWeaponOfType(chr, Const.CrossbowType))
-        {
-            giveBolts(chr);
-        }
+        { giveBolts(chr); }
+
         chr.equipSubBolt = Const.NoItem;
         chr.subBoltNum = ushort.MaxValue;
         if (hasWeaponOfType(chr, Const.BallistaType))
-        {
-            giveBallistaBolts(chr);
-        }
+        { giveBallistaBolts(chr); }
+
         chr.equipSpell01 = -1;
         chr.equipSpell02 = -1;
     }

--- a/src/ERBingoRandomizer/Tasks/Randomizer.Stats.cs
+++ b/src/ERBingoRandomizer/Tasks/Randomizer.Stats.cs
@@ -1,5 +1,6 @@
-﻿using Project.Params;
+﻿using System.Collections.Generic;
 using FSParam;
+using Project.Params;
 using Project.Settings;
 
 namespace Project.Tasks;
@@ -19,55 +20,64 @@ public partial class Randomizer
         tarnished.baseFai = Config.MinStat;
     }
     private void increaseStats(int iterations, CharaInitParam tarnished)
-    {
-        int lastUpdated = -1;
-        int stat = 0; // bumps vigor on 1st iteration
+    {   // There are a fixed number of 8 class stats in the game (0 to 7)
+        List<int> stats = new List<int>() { 0, 1, 2, 3, 4, 5, 6, 7 };
+        int index = 0;
+        int stat = stats[index]; // bumps vigor on 1st iteration
         while (iterations > 0)
         {
             _cancellationToken.ThrowIfCancellationRequested();
-            if ((iterations & 1) == 0 && lastUpdated == stat) stat = _random.Next(Const.NumStats);
-            //^ decreases chance of a repeat increase by checking to redraw every other iteration. 
             switch (stat)
-            {   // There are a fixed number of 8 class stats in the game (0 to 7)
+            {
                 case 0:
                     iterations -= validateIncrease(tarnished.GetVitCell());
+                    if (exceedsMaxStat(tarnished.GetVitCell())) { stats.Remove(0); }
                     break;
                 case 1:
                     iterations -= validateIncrease(tarnished.GetWilCell());
+                    if (exceedsMaxStat(tarnished.GetWilCell())) { stats.Remove(1); }
                     break;
                 case 2:
                     iterations -= validateIncrease(tarnished.GetEndCell());
+                    if (exceedsMaxStat(tarnished.GetEndCell())) { stats.Remove(2); }
                     break;
                 case 3:
                     iterations -= validateIncrease(tarnished.GetStrCell());
+                    if (exceedsMaxStat(tarnished.GetStrCell())) { stats.Remove(3); }
                     break;
                 case 4:
                     iterations -= validateIncrease(tarnished.GetDexCell());
+                    if (exceedsMaxStat(tarnished.GetDexCell())) { stats.Remove(4); }
                     break;
                 case 5:
                     iterations -= validateIncrease(tarnished.GetMagCell());
+                    if (exceedsMaxStat(tarnished.GetMagCell())) { stats.Remove(5); }
                     break;
                 case 6:
                     iterations -= validateIncrease(tarnished.GetFaiCell());
+                    if (exceedsMaxStat(tarnished.GetFaiCell())) { stats.Remove(6); }
                     break;
                 case 7:
                     iterations -= validateIncrease(tarnished.GetLucCell());
+                    if (exceedsMaxStat(tarnished.GetLucCell())) { stats.Remove(7); }
                     break;
             }
-            lastUpdated = stat;
-            stat = _random.Next(Const.NumStats);
+            index = _random.Next(stats.Count);
+            stat = stats[index];
         }
     }
     private int validateIncrease(Param.Cell entry)
     {
         byte value = (byte)entry.Value;
+
         if (value >= Config.MaxStat)
-        {
-            return 0;
-        }
+        { return 0; }
+
         entry.Value = (byte)(value + 1);
         return 1; // adjust iterations
     }
+
+    private bool exceedsMaxStat(Param.Cell entry) { return Config.MaxStat <= (byte)entry.Value; }
 
     private void setClassStats(CharaInitParam tarnished)
     {


### PR DESCRIPTION
Updated gear to be unique allocations, preparation for new allocations to spells and remembrance weapons.

Added logic to level allocations to mitigate rare infinite loops. Now if a stat reaches max value it is removed from a list of stats that can be leveled.