### PR TITLE
Weapon Allocation Update

### DIFF
--- a/src/ERBingoRandomizer/MainWindow.xaml
+++ b/src/ERBingoRandomizer/MainWindow.xaml
@@ -7,7 +7,7 @@
         xmlns:localConverter="clr-namespace:Randomizer.Converter"
         mc:Ignorable="d"
         xmlns:gif="http://wpfanimatedgif.codeplex.com"
-        Title="Equipment Randomizer v0.55"
+        Title="Equipment Randomizer v0.59"
         Height="500"
         Width="800"
         ResizeMode="CanResizeWithGrip"

--- a/src/ERBingoRandomizer/Randomizer.csproj
+++ b/src/ERBingoRandomizer/Randomizer.csproj
@@ -41,7 +41,7 @@
         <Message Text="Moving Readme: $(PublishDir)" Importance="High" />
         <Message Text="Solution Dir: $(SolutionDir)" Importance="High" />
         <Copy SourceFiles="$(SolutionDir)README.md" DestinationFiles="$(PublishDir)README.txt" />
-        <Move SourceFiles="$(PublishDir)\$(AssemblyName).exe" DestinationFiles="$(PublishDir)\ER_EquipmentRandomizer0.55.exe" />
+        <Move SourceFiles="$(PublishDir)\$(AssemblyName).exe" DestinationFiles="$(PublishDir)\ER_EquipmentRandomizer0.59.exe" />
         <Message Text="Renamed executable file." Importance="high" />
         <!--<Exec Command="7za.exe a -t7z &quot;Elden Ring Debug Tool.7z&quot; .\bin\Publish\win-x64\* -xr!*.pdb" />
         <Move SourceFiles="Elden Ring Debug Tool.7z" DestinationFiles="$(PublishDir)..\Elden Ring Debug Tool $(AssemblyVersion).7z" />-->

--- a/src/ERBingoRandomizer/Settings/Equipment.cs
+++ b/src/ERBingoRandomizer/Settings/Equipment.cs
@@ -51,6 +51,7 @@ public class Equipment
         new ItemLotWrapper(new ItemLotEntry(15500000, 2), Const.GreataxeType), //  Death Knight's Longhaft Axe
         new ItemLotWrapper(new ItemLotEntry(17520000, 2), Const.GreatSpearType), // Barbed Staff-Spear
         new ItemLotWrapper(new ItemLotEntry(10510000, 2), Const.TwinbladeType), //  Blacksteel Twinblade
+        new ItemLotWrapper(new ItemLotEntry(13500000, 2), Const.FlailType), //  Serpent Flail
     };
 
     public static List<int> CurvedSwordIDs = new List<int>()
@@ -130,6 +131,11 @@ public class Equipment
     {
         13000000, 13010000, 13020000, 13040000,
         // 13500000, // DLC
+    };
+    public static List<int> MerchantSpearIDs = new List<int>
+    {
+        17520000, 16550000, 17060000, 17050000, 16140000,
+        16000000, 16520000, 16540000, 16050000, 16110000, 16030000,
     };
     public static List<int> GreatSpearIDs = new List<int>
     {   // serpent hunter is deliberately excluded 17030000
@@ -252,15 +258,44 @@ public class Equipment
         44000000, 44010000, 42010000, 42030000, 42040000, 
         // 42500000, 63500000, 44500000, (DLC)
     };
-    public static List<int> DlcSideIDs = new List<int>
+    public static List<int> DlcAndSalt = new List<int>
     {
-        64520000, // Curseblade's Cirque
-        7510000,  // Falx
+        1500000,  // main gauche
+        1020000,  // parrying dagger
         22500000, // Claws of Night
+        68500000, // Beast Claw
+        68510000, // Red Bear Beast Claw
+        21540000, // Golem Fist
+        21510000, // Pata
+        23500000, // Devonia's Hammer
+        4500000,  // Ancient Meteoric Ore
         40500000, // Bone Bow
         43500000, // Repeating Crossbow
         43510000, // Spread Crossbow
         41510000, // Ansbach's Bow
+        30510000, // small shield
+        21550000, // small shield
+        16520000, // swift spear
+        16540000, // bloodfiend's fork
+        64520000, // Curseblade's Cirque
+        7510000,  // Falx
+        7520000,  // Dancing Blade of Ranah
+        7530000,  // Horned Warrior's Sword 
+        7080000,  // scavengers
+        13500000, // Serpent Flail
+        66500000, // Great Katana
+        9500000, // Sword of Knight
+        12520000, // Blacksteel Greathammer
+        17520000, // Barbed Staff spear
+        3520000, // Lizard Greatsword
+        11500000, // Flowerstone Gavel
+        67500000, // Milady
+        67510000, // Leda's Sword
+        19500000, // Obsidian Lomina
+        31500000, // 
+        31510000, //
+        31520000, // 
+        31530000, //
     };
 
     // SORCERIES
@@ -311,20 +346,6 @@ public class Equipment
         10000000, 10010000, 10030000, 10080000, 9000000, 9030000, 9040000, 9060000, 9070000, 9080000, // twin blades / katana
         23130000, 15050000, 15020000, 15060000, 12000000, 12020000, 12180000, 12010000, 4040000, 4000000, // troll's hammer, longhaft axe
     };
-    public static IReadOnlyList<List<int>> MainWeaponLists = new List<List<int>>() {
-        StraightSwordIDs, CurvedSwordIDs, AxeIDs, HalberdIDs, HammerIDs, KatanaIDs,
-        GreataxeIDs, GreatHammerIDs, GreatSpearIDs, GreatswordIDs, CurvedGreatSwordIDs,
-        TwinbladeIDs, ReaperIDs, HeavyThrustingIDs, DaggerIDs,
-    };
-    public static IReadOnlyList<List<int>> SideWeaponLists = new List<List<int>>() {
-        ClawIDs, DaggerIDs, FistIDs, ThrustingSwordIDs, WhipIDs, FlailIDs,
-        GreatShieldIDs, MediumShieldIDs, SmallShieldIDs, LightBowAndBowIDs, BallistaOrGreatBowIDs,
-    };
-    // public static IReadOnlyList<List<int>> WeaponShopLists = new List<List<int>>() {
-    //     DaggerIDs, FistIDs, LightBowAndBowIDs, SmallShieldIDs, MediumShieldIDs, TorchIDs, ColossalWeaponIDs,
-    //     CurvedGreatSwordIDs, HammerIDs, StraightSwordIDs, CurvedSwordIDs, ReaperIDs, TwinbladeIDs,
-    //     DlcHeavyShopIDs, DlcLightShopIDs, DlcSmithingIDs, // GreatswordIDs, GreataxeIDs, 
-    // };
 
     // ARMOR
     public static List<int> HeadArmorIDs = new List<int>()

--- a/src/ERBingoRandomizer/Tasks/Randomizer.Helpers.cs
+++ b/src/ERBingoRandomizer/Tasks/Randomizer.Helpers.cs
@@ -105,10 +105,9 @@ public partial class Randomizer
         {
             List<ItemLotEntry> value = (List<ItemLotEntry>)orderedDictionary[i]!;
             List<ItemLotEntry> itemLotEntries = new(value);
-            itemLotEntries.Shuffle(_random); // TODO investigate if thise matters
+            itemLotEntries.Shuffle(_random);
 
-            foreach (ItemLotEntry entry in itemLotEntries)
-            { dict.Add(entry.Id, getNewId(entry.Id, value)); }
+            foreach (ItemLotEntry entry in itemLotEntries) { dict.Add(entry.Id, getNewId(entry.Id, value)); }
         }
         return dict;
     }
@@ -120,8 +119,8 @@ public partial class Randomizer
             List<int> value = (List<int>)orderedDictionary[i]!;
             List<int> itemLotEntries = new(value);
             itemLotEntries.Shuffle(_random); // TODO investigate if thise matters
-            foreach (int entry in itemLotEntries)
-            { output.Add(entry, getNewId(entry, value)); }
+
+            foreach (int entry in itemLotEntries) { output.Add(entry, getNewId(entry, value)); }
         }
         return output;
     }

--- a/src/ERBingoRandomizer/Tasks/Randomizer.Helpers.cs
+++ b/src/ERBingoRandomizer/Tasks/Randomizer.Helpers.cs
@@ -85,6 +85,7 @@ public partial class Randomizer
     {
         Dictionary<int, ItemLotEntry> dict = new();
 
+        // consolidate all ranged armamets
         List<ItemLotEntry> bows = (List<ItemLotEntry>?)orderedDictionary[(object)Const.BowType] ?? new List<ItemLotEntry>();
         List<ItemLotEntry> lightbows = (List<ItemLotEntry>?)orderedDictionary[(object)Const.LightBowType] ?? new List<ItemLotEntry>();
         List<ItemLotEntry> greatbows = (List<ItemLotEntry>?)orderedDictionary[(object)Const.GreatbowType] ?? new List<ItemLotEntry>();
@@ -101,13 +102,28 @@ public partial class Randomizer
         orderedDictionary.Remove(Const.CrossbowType);
         orderedDictionary.Remove(Const.BallistaType);
 
+        // consolidate colossals
+        List<ItemLotEntry> colSwords = (List<ItemLotEntry>?)orderedDictionary[(object)Const.ColossalSwordType] ?? new List<ItemLotEntry>();
+        List<ItemLotEntry> colWeapons = (List<ItemLotEntry>?)orderedDictionary[(object)Const.ColossalWeaponType] ?? new List<ItemLotEntry>();
+        colWeapons.AddRange(colSwords);
+        orderedDictionary[(object)Const.ColossalWeaponType] = colWeapons;
+        orderedDictionary.Remove(Const.ColossalSwordType);
+
+        // consolidate axes and hammers
+        // List<ItemLotEntry> axes = (List<ItemLotEntry>?)orderedDictionary[(object)Const.AxeType] ?? new List<ItemLotEntry>();
+        // List<ItemLotEntry> hammers = (List<ItemLotEntry>?)orderedDictionary[(object)Const.HammerType] ?? new List<ItemLotEntry>();
+        // axes.AddRange(hammers);
+        // orderedDictionary[(object)Const.AxeType] = axes;
+        // orderedDictionary.Remove(Const.HammerType);
+
         for (int i = 0; i < orderedDictionary.Count; i++)
         {
             List<ItemLotEntry> value = (List<ItemLotEntry>)orderedDictionary[i]!;
             List<ItemLotEntry> itemLotEntries = new(value);
             itemLotEntries.Shuffle(_random);
 
-            foreach (ItemLotEntry entry in itemLotEntries) { dict.Add(entry.Id, getNewId(entry.Id, value)); }
+            foreach (ItemLotEntry entry in itemLotEntries)
+            { dict.Add(entry.Id, getNewId(entry.Id, value)); }
         }
         return dict;
     }
@@ -145,31 +161,6 @@ public partial class Randomizer
         }
     }
 
-    private void replaceShopLineupParam(ShopLineupParam lot, IList<int> shopLineupList, IList<int> remembranceList)
-    {
-        int newId = 0;
-        if (lot.mtrlId == -1)
-        {
-            int limit = shopLineupList.Count;
-            int index = _random.Next(limit);
-            newId = shopLineupList[index];
-        }
-        else
-        {
-            int limit = remembranceList.Count;
-            int index = _random.Next(limit);
-            newId = remembranceList[index];
-            remembranceList.Remove(newId);
-        }
-        lot.equipId = newId;
-        // int newId = getNewId(lot.equipId, shopLineupParamDictionary);
-        // TODO: currently has DLC weapons available, longterm will want DLC items read as params 
-        // logItem($"{_weaponNameDictionary[lot.equipId]} --> {Equipment.EquipmentNameList[newId]}");
-
-        // ShopLineupParam newRemembrance = getNewId(lot.equipId, shopLineupParamRemembranceList);
-        // logItem($"{_weaponNameDictionary[lot.equipId]} --> {_weaponNameDictionary[newRemembrance.equipId]}");
-        // copyShopLineupParam(lot, newRemembrance);
-    }
     private void replaceShopLineupParamMagic(ShopLineupParam lot, IReadOnlyDictionary<int, int> shopLineupParamDictionary, IList<ShopLineupParam> shopLineupParamRemembranceList)
     {
         if (lot.mtrlId == -1)

--- a/src/ERBingoRandomizer/Tasks/Randomizer.Regulation.cs
+++ b/src/ERBingoRandomizer/Tasks/Randomizer.Regulation.cs
@@ -134,14 +134,13 @@ public partial class Randomizer
             for (int i = 0; i < Const.ItemLots; i++)
             {
                 int category = (int)categories[i].GetValue(row);
+
                 if (category != Const.ItemLotWeaponCategory && category != Const.ItemLotCustomWeaponCategory)
                 { continue; }
 
                 int id = (int)itemIds[i].GetValue(row);
-                //> Should work if it were item lot entries
-
-                //^ TODO revisit for longterm
                 int sanitizedId = washWeaponLevels(id);
+
                 if (category == Const.ItemLotWeaponCategory)
                 {
                     if (!_weaponDictionary.TryGetValue(sanitizedId, out EquipParamWeapon? wep)) { continue; }
@@ -219,8 +218,7 @@ public partial class Randomizer
                         categories[i].SetValue(row, entry.Category);
                         break;
                     }
-                    if (!chanceDropReplace.TryGetValue(id, out entry))
-                    { continue; }
+                    if (!chanceDropReplace.TryGetValue(id, out entry)) { continue; }
 
                     itemIds[i].SetValue(row, entry.Id);
                     categories[i].SetValue(row, entry.Category);

--- a/src/ERBingoRandomizer/Tasks/Randomizer.Regulation.cs
+++ b/src/ERBingoRandomizer/Tasks/Randomizer.Regulation.cs
@@ -44,8 +44,9 @@ public partial class Randomizer
         _cancellationToken.ThrowIfCancellationRequested();
         randomizeShopLineupParamMagic();
         _cancellationToken.ThrowIfCancellationRequested();
-        patchAtkParam();
+        randomizeShopArmorParam();
         _cancellationToken.ThrowIfCancellationRequested();
+        patchAtkParam();
         patchSmithingStones();
         _cancellationToken.ThrowIfCancellationRequested();
         writeFiles();
@@ -63,6 +64,17 @@ public partial class Randomizer
 
         List<Param.Row> staves = _weaponTypeDictionary[Const.StaffType];
         List<Param.Row> seals = _weaponTypeDictionary[Const.SealType];
+
+        IEnumerable<int> remembranceItems = _shopLineupParam.Rows.Where(r => r.ID is >= 101900 and <= 101929)
+            .Select(r => new ShopLineupParam(r).equipId);
+
+        List<int> spells = _magicDictionary.Keys.Select(id => id).Distinct()
+            .Where(id => remembranceItems.All(r => r != id))
+            .Where(id => staves.All(s => s.ID != id)
+                && seals.All(s => s.ID != id))
+            .ToList();
+        // spells.Shuffle(_random);
+
         List<Param.Row> bows = _weaponTypeDictionary[Const.BowType];
         List<Param.Row> lightbows = _weaponTypeDictionary[Const.LightBowType];
         List<Param.Row> greatbows = _weaponTypeDictionary[Const.GreatbowType];
@@ -72,22 +84,16 @@ public partial class Randomizer
         List<Param.Row> mediumShields = _weaponTypeDictionary[Const.MediumShieldType];
         List<Param.Row> greatShields = _weaponTypeDictionary[Const.GreatShieldType];
         List<Param.Row> claws = _weaponTypeDictionary[Const.ClawType];
+        List<Param.Row> daggers = _weaponTypeDictionary[Const.DaggerType];
         List<Param.Row> fists = _weaponTypeDictionary[Const.FistType];
-
-        IEnumerable<int> remembranceItems = _shopLineupParam.Rows.Where(r => r.ID is >= 101900 and <= 101929)
-            .Select(r => new ShopLineupParam(r).equipId);
-
-        List<int> spells = _magicDictionary.Keys.Select(id => id).Distinct()
-            .Where(id => remembranceItems.All(r => r != id))
-            .Where(id => staves.All(s => s.ID != id) && seals.All(s => s.ID != id))
-            .ToList();
-        spells.Shuffle(_random);
+        List<Param.Row> colossalWeapons = _weaponTypeDictionary[Const.ColossalWeaponType];
 
         List<int> weapons = _weaponDictionary.Keys.Select(washWeaponLevels).Distinct()
             .Where(id => remembranceItems.All(i => i != id))
             .Where(id => staves.All(s => s.ID != id)
                 && seals.All(s => s.ID != id)
                 && bows.All(s => s.ID != id)
+                && colossalWeapons.All(s => s.ID != id)
                 && lightbows.All(s => s.ID != id)
                 && greatbows.All(s => s.ID != id)
                 && ballistae.All(s => s.ID != id)
@@ -95,20 +101,50 @@ public partial class Randomizer
                 && mediumShields.All(s => s.ID != id)
                 && greatShields.All(s => s.ID != id)
                 && claws.All(s => s.ID != id)
-                && fists.All(s => s.ID != id)
-            ).ToList();
-        weapons.Shuffle(_random);
+                && daggers.All(s => s.ID != id)
+                && fists.All(s => s.ID != id))
+            .ToList();
+
+        List<Param.Row> greatswords = _weaponTypeDictionary[Const.GreatswordType];
+        List<Param.Row> colossalSwords = _weaponTypeDictionary[Const.ColossalSwordType];
+        List<Param.Row> curvedGreatswords = _weaponTypeDictionary[Const.CurvedGreatswordType];
+        List<Param.Row> katanas = _weaponTypeDictionary[Const.KatanaType];
+        List<Param.Row> twinblades = _weaponTypeDictionary[Const.TwinbladeType];
+        List<Param.Row> heavyThrusting = _weaponTypeDictionary[Const.HeavyThrustingType];
+        List<Param.Row> axes = _weaponTypeDictionary[Const.AxeType];
+        List<Param.Row> greataxes = _weaponTypeDictionary[Const.GreataxeType];
+        List<Param.Row> hammers = _weaponTypeDictionary[Const.HammerType];
+        List<Param.Row> greatHammers = _weaponTypeDictionary[Const.GreatHammerType];
+        List<Param.Row> spears = _weaponTypeDictionary[Const.SpearType];
+        List<Param.Row> greatSpears = _weaponTypeDictionary[Const.GreatSpearType];
+        List<Param.Row> halberds = _weaponTypeDictionary[Const.HalberdType];
+        List<Param.Row> reapers = _weaponTypeDictionary[Const.ReaperType];
+
+        List<int> sideArms = _weaponDictionary.Keys.Select(washWeaponLevels).Distinct()
+            .Where(id => remembranceItems.All(i => i != id))
+            .Where(id => staves.All(s => s.ID != id)
+                && seals.All(s => s.ID != id)
+                && greatswords.All(s => s.ID != id)
+                && colossalSwords.All(s => s.ID != id)
+                && curvedGreatswords.All(s => s.ID != id)
+                && katanas.All(s => s.ID != id)
+                && twinblades.All(s => s.ID != id)
+                && heavyThrusting.All(s => s.ID != id)
+                && axes.All(s => s.ID != id)
+                && greataxes.All(s => s.ID != id)
+                && hammers.All(s => s.ID != id)
+                && greatHammers.All(s => s.ID != id)
+                && spears.All(s => s.ID != id)
+                && greatSpears.All(s => s.ID != id)
+                && halberds.All(s => s.ID != id)
+                && reapers.All(s => s.ID != id)
+                && greatShields.All(s => s.ID != id))
+            .ToList();
 
         for (int i = 0; i < Config.NumberOfClasses; i++)
         {
             Param.Row? row = _charaInitParam[Config.FirstClassId + i];
             if (row == null) { continue; }
-
-            int index = _random.Next(Equipment.SideWeaponLists.Count);
-            List<int> sideArms = Equipment.SideWeaponLists[index];
-            index = _random.Next(Equipment.MainWeaponLists.Count);
-            List<int> main = Equipment.MainWeaponLists[index];
-            // List<int> main = Equipment.StartingWeaponIDs;
 
             CharaInitParam startingClass = new(row);
             randomizeEquipment(startingClass, weapons, sideArms);
@@ -188,6 +224,17 @@ public partial class Randomizer
         Dictionary<int, ItemLotEntry> guaranteedDropReplace = getReplacementHashmap(categoryDictMap);
         Dictionary<int, ItemLotEntry> chanceDropReplace = getReplacementHashmap(categoryDictEnemy);
 
+        /*
+                string docPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments); // TODO remove
+
+                foreach (KeyValuePair<int, ItemLotEntry> pair in guaranteedDropReplace)
+                {
+                    using (StreamWriter outputFile = new StreamWriter(Path.Combine(docPath, "WriteLines.txt"), true))
+                    {
+                        outputFile.WriteLine($" {guaranteedDropReplace[pair.Value.Category]}, {guaranteedDropReplace[pair.Value.Id]}");
+                    }
+                }
+        */
         // Application now has weapons set to randomize
         // logItem(">> Item Replacements - all instances of item on left will be replaced with item on right");
         // logItem("## Guaranteed Weapons");
@@ -242,28 +289,41 @@ public partial class Randomizer
             }
         }
     }
-    private void randomizeShopLineupParam() //TODO add armor randomization, TODO randomize away from Carian Regal Scepter
+    private void randomizeShopLineupParam()
     {
-        string docPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments); // TODO remove
-
+        // HashSet<int> allocatedIDs = new HashSet<int>();
+        List<List<int>> WeaponShopLists = new List<List<int>>() {
+            Equipment.LightBowAndBowIDs, Equipment.CrossBowIDs,
+            Equipment.SmallShieldIDs, Equipment.MediumShieldIDs,
+            Equipment.ColossalWeaponIDs, Equipment.ColossalSwordIDs,
+            Equipment.DaggerClawFistIDs, Equipment.TorchIDs,
+            Equipment.CurvedSwordIDs, Equipment.CurvedGreatSwordIDs,
+            Equipment.HammerIDs, Equipment.GreatHammerIDs,
+            Equipment.AxeIDs, Equipment.GreataxeIDs,
+            Equipment.StraightSwordIDs, Equipment.GreatswordIDs,
+            Equipment.ReaperIDs, Equipment.KatanaIDs,
+            Equipment.TwinbladeIDs, Equipment.HeavyThrustingIDs,
+            Equipment.MerchantSpearIDs, Equipment.ThrustingSwordIDs,
+            Equipment.DlcAndSalt,
+        };
+        List<int> RemembranceWeaponIDs = new List<int>()
+        {
+            3100000, 3140000, 4020000, 4050000, 6040000, 8100000, 9020000, 11150000,
+            13030000, 15040000, 15110000, 17010000,  20060000, 21060000, 23050000,
+            42000000,
+            3500000, 3510000, 8500000, 17500000, 18510000, 23510000, 23520000, 67520000, // DLC  // 4530000, 4550000,  // Radahn's DLC swords
+        };
         List<ShopLineupParam> shopLineupParamRemembranceList = new();
+
         foreach (Param.Row row in _shopLineupParam.Rows)
         {
-            /*  
-                using (StreamWriter outputFile = new StreamWriter(Path.Combine(docPath, "WriteLines.txt"), true))
-                {
-                            outputFile.WriteLine($" id {row.ID}, value: {col.GetValue(row)} <>");
-                }
-            */
-
             if ((byte)row["equipType"]!.Value.Value != Const.ShopLineupWeaponCategory || (row.ID < 101900 || row.ID > 101980))
-            { continue; } // assures only weapons are randomized TODO update for armor
+            { continue; } // assures only weapons are randomized, maybe update for different armor logic, not sure
 
             ShopLineupParam lot = new(new Param.Row(row));
             int sanitizedId = washWeaponLevels(lot.equipId);
 
-            if (!_weaponDictionary.TryGetValue(sanitizedId, out _))
-            { continue; }
+            if (!_weaponDictionary.TryGetValue(sanitizedId, out _)) { continue; }
 
             if (lot.equipId != sanitizedId)
             {
@@ -274,29 +334,9 @@ public partial class Randomizer
 
         // logItem("<> Shop Replacements - Random item selected from pool of all weapons (not including infused weapons). Remembrances are randomized amongst each-other.");
 
-        List<int> RemembranceWeaponIDs = new List<int>()
-        {
-            3100000, 3140000, 4020000, 4050000, 6040000, 8100000, 9020000, 11150000,
-            13030000, 15040000, 15110000, 17010000,  20060000, 21060000, 23050000,
-            42000000,
-            // 4530000, 4550000,  // Radahn's DLC swords
-            // DLC
-            3500000, 3510000, 8500000, 17500000, 18510000, 23510000, 23520000, 67520000,
-        };
-
-        List<List<int>> WeaponShopLists = new List<List<int>>() {
-            Equipment.LightBowAndBowIDs, Equipment.SmallShieldIDs, Equipment.MediumShieldIDs, Equipment.TorchIDs,
-            Equipment.ColossalWeaponIDs, Equipment.CurvedGreatSwordIDs, Equipment.HammerIDs, Equipment.StraightSwordIDs,
-            Equipment.CurvedSwordIDs, Equipment.ReaperIDs, Equipment.TwinbladeIDs, Equipment.DaggerClawFistIDs,
-            Equipment.GreatswordIDs, Equipment.KatanaIDs, Equipment.HeavyThrustingIDs, Equipment.AxeIDs,
-            Equipment.DlcSideIDs,
-        };
-
         foreach (Param.Row row in _shopLineupParam.Rows)
         {
-            if ((byte)row["equipType"]!.Value.Value != Const.ShopLineupWeaponCategory
-                || row.ID > 101980
-            ) // TODO find out what this row.ID is removes 20 lots
+            if ((byte)row["equipType"]!.Value.Value != Const.ShopLineupWeaponCategory || row.ID > 101980) // TODO find out what this row.ID is, removes ~20 lots
             { continue; }
 
             ShopLineupParam lot = new(row);
@@ -306,12 +346,142 @@ public partial class Randomizer
 
             if (lot.equipId == Const.CarianRegalScepter || !(wep.wepType is Const.StaffType or Const.SealType))
             {   // about 60 item shop allocations
-                int index = _random.Next(WeaponShopLists.Count);
-                List<int> weaponIndex = WeaponShopLists[index];
-
-                replaceShopLineupParam(lot, weaponIndex, RemembranceWeaponIDs);
+                if (lot.mtrlId == -1)
+                { replaceWeaponLineupParam(lot, WeaponShopLists); }
+                else
+                { replaceRemembranceLineupParam(lot, RemembranceWeaponIDs); } // list is small, better to have seperate unique allocation logic
             }
         }
+    }
+    private void randomizeShopLineupParamMagic()
+    {
+        OrderedDictionary magicCategoryDictMap = new();
+        List<ShopLineupParam> shopLineupParamRemembranceList = new();
+        List<ShopLineupParam> shopLineupParamDragonList = new();
+        foreach (Param.Row row in _shopLineupParam.Rows)
+        {
+            if ((byte)row["equipType"]!.Value.Value != Const.ShopLineupGoodsCategory || row.ID > 101980)
+            { continue; }
+
+            ShopLineupParam lot = new(new Param.Row(row));
+            if (!_magicDictionary.TryGetValue(lot.equipId, out Magic? magic)) { continue; }
+
+            if (row.ID < 101950)
+            {
+                if (lot.mtrlId == -1)
+                {
+                    addToOrderedDict(magicCategoryDictMap, magic.ezStateBehaviorType, lot.equipId);
+                    continue;
+                }
+                shopLineupParamRemembranceList.Add(lot);
+            }
+            else
+            { shopLineupParamDragonList.Add(lot); } // Dragon Communion Shop 101950 - 101980 
+        }
+
+        foreach (Param.Row row in _itemLotParam_enemy.Rows.Concat(_itemLotParam_map.Rows))
+        {
+            Param.Column[] itemIds = row.Cells.Take(Const.ItemLots).ToArray();
+            Param.Column[] categories = row.Cells.Skip(Const.CategoriesStart).Take(Const.ItemLots).ToArray();
+            Param.Column[] chances = row.Cells.Skip(Const.ChanceStart).Take(Const.ItemLots).ToArray();
+            int totalWeight = chances.Sum(a => (ushort)a.GetValue(row));
+            for (int i = 0; i < Const.ItemLots; i++)
+            {
+                int category = (int)categories[i].GetValue(row);
+                if (category != Const.ItemLotGoodsCategory) { continue; }
+
+                int id = (int)itemIds[i].GetValue(row);
+                if (!_magicDictionary.TryGetValue(id, out Magic? magic)) { continue; }
+
+                ushort chance = (ushort)chances[i].GetValue(row);
+                if (chance == totalWeight)
+                {
+                    addToOrderedDict(magicCategoryDictMap, magic.ezStateBehaviorType, id);
+                    break;
+                }
+                addToOrderedDict(magicCategoryDictMap, magic.ezStateBehaviorType, id);
+            }
+        }
+
+        dedupeAndRandomizeShopVectors(magicCategoryDictMap);
+
+        Dictionary<int, int> magicShopReplacement = getShopReplacementHashmap(magicCategoryDictMap);
+        shopLineupParamRemembranceList.Shuffle(_random);
+        shopLineupParamDragonList.Shuffle(_random);
+        // logItem("\n## All Magic Replacement.");
+        // logReplacementDictionaryMagic(magicShopReplacement);
+
+        // logItem("\n~* Shop Magic Replacement.");
+        foreach (Param.Row row in _shopLineupParam.Rows)
+        {
+            // logShopIdMagic(row.ID);
+            if ((byte)row["equipType"]!.Value.Value != Const.ShopLineupGoodsCategory || row.ID > 101980)
+            { continue; }
+
+            ShopLineupParam lot = new(row);
+            if (!_magicDictionary.TryGetValue(lot.equipId, out _)) { continue; }
+
+            if (row.ID < 101950)
+            { replaceShopLineupParamMagic(lot, magicShopReplacement, shopLineupParamRemembranceList); }
+
+            else
+            {
+                ShopLineupParam newDragonIncant = getNewId(lot.equipId, shopLineupParamDragonList);
+                // logItem($"{_goodsFmg[lot.equipId]} -> {_goodsFmg[newDragonIncant.equipId]}");
+                copyShopLineupParam(lot, newDragonIncant);
+            }
+        }
+
+        foreach (Param.Row row in _itemLotParam_enemy.Rows.Concat(_itemLotParam_map.Rows))
+        {
+            Param.Column[] itemIds = row.Cells.Take(Const.ItemLots).ToArray();
+            Param.Column[] categories = row.Cells.Skip(Const.CategoriesStart).Take(Const.ItemLots).ToArray();
+            for (int i = 0; i < Const.ItemLots; i++)
+            {
+                int category = (int)categories[i].GetValue(row);
+                if (category != Const.ItemLotGoodsCategory) { continue; }
+
+                int id = (int)itemIds[i].GetValue(row);
+                if (!_magicDictionary.TryGetValue(id, out Magic _)) { continue; }
+                if (!magicShopReplacement.TryGetValue(id, out int entry)) { continue; }
+
+                itemIds[i].SetValue(row, entry);
+            }
+        }
+    }
+    private void replaceWeaponLineupParam(ShopLineupParam lot, List<List<int>> WeaponShopLists)
+    {
+        int newID = 0;
+        do
+        {
+            _cancellationToken.ThrowIfCancellationRequested();
+            int weaponCategory = _random.Next(WeaponShopLists.Count);
+            List<int> weaponList = WeaponShopLists[weaponCategory];
+            int index = _random.Next(weaponList.Count);
+            newID = weaponList[index];
+        } while (allocatedIDs.Contains(newID));
+
+        lot.equipId = newID;
+        allocatedIDs.Add(newID);
+    }
+    private void replaceRemembranceLineupParam(ShopLineupParam lot, IList<int> remembranceList)
+    {
+        int limit = remembranceList.Count;
+        int index = _random.Next(limit);
+        int newId = remembranceList[index];
+        remembranceList.Remove(newId);
+        // }
+        lot.equipId = newId;
+        // int newId = getNewId(lot.equipId, shopLineupParamDictionary);
+        // TODO: currently has DLC weapons available, longterm will want DLC items read as params 
+        // logItem($"{_weaponNameDictionary[lot.equipId]} --> {Equipment.EquipmentNameList[newId]}");
+
+        // ShopLineupParam newRemembrance = getNewId(lot.equipId, shopLineupParamRemembranceList);
+        // logItem($"{_weaponNameDictionary[lot.equipId]} --> {_weaponNameDictionary[newRemembrance.equipId]}");
+        // copyShopLineupParam(lot, newRemembrance);
+    }
+    private void randomizeShopArmorParam()
+    {
         List<int> baseHeadProtectors = new List<int>()
         {
             40000, 160000, 210000, 280000, 620000, 630000, 660000, 670000, 730000, 870000,
@@ -360,106 +530,6 @@ public partial class Randomizer
                     int index = _random.Next(Equipment.LegsArmorIDs.Count);
                     lot.equipId = Equipment.LegsArmorIDs[index];
                 }
-
-            }
-        }
-    }
-    private void randomizeShopLineupParamMagic()
-    {
-        OrderedDictionary magicCategoryDictMap = new();
-        List<ShopLineupParam> shopLineupParamRemembranceList = new();
-        List<ShopLineupParam> shopLineupParamDragonList = new();
-        foreach (Param.Row row in _shopLineupParam.Rows)
-        {
-            if ((byte)row["equipType"]!.Value.Value != Const.ShopLineupGoodsCategory || row.ID > 101980)
-            { continue; }
-
-            ShopLineupParam lot = new(new Param.Row(row));
-            if (!_magicDictionary.TryGetValue(lot.equipId, out Magic? magic)) { continue; }
-
-            if (row.ID < 101950)
-            {
-                if (lot.mtrlId == -1)
-                {
-                    addToOrderedDict(magicCategoryDictMap, magic.ezStateBehaviorType, lot.equipId);
-                    continue;
-                }
-                shopLineupParamRemembranceList.Add(lot);
-            }
-            else
-            { // Dragon Communion Shop 101950 - 101980 
-                shopLineupParamDragonList.Add(lot);
-            }
-        }
-
-        foreach (Param.Row row in _itemLotParam_enemy.Rows.Concat(_itemLotParam_map.Rows))
-        {
-            Param.Column[] itemIds = row.Cells.Take(Const.ItemLots).ToArray();
-            Param.Column[] categories = row.Cells.Skip(Const.CategoriesStart).Take(Const.ItemLots).ToArray();
-            Param.Column[] chances = row.Cells.Skip(Const.ChanceStart).Take(Const.ItemLots).ToArray();
-            int totalWeight = chances.Sum(a => (ushort)a.GetValue(row));
-            for (int i = 0; i < Const.ItemLots; i++)
-            {
-                int category = (int)categories[i].GetValue(row);
-                if (category != Const.ItemLotGoodsCategory) { continue; }
-
-                int id = (int)itemIds[i].GetValue(row);
-                if (!_magicDictionary.TryGetValue(id, out Magic? magic)) { continue; }
-
-                ushort chance = (ushort)chances[i].GetValue(row);
-                if (chance == totalWeight)
-                {
-                    addToOrderedDict(magicCategoryDictMap, magic.ezStateBehaviorType, id);
-                    break;
-                }
-                addToOrderedDict(magicCategoryDictMap, magic.ezStateBehaviorType, id);
-            }
-        }
-
-        dedupeAndRandomizeShopVectors(magicCategoryDictMap);
-
-        Dictionary<int, int> magicShopReplacement = getShopReplacementHashmap(magicCategoryDictMap);
-        shopLineupParamRemembranceList.Shuffle(_random); // TODO investigate if thise matters
-        shopLineupParamDragonList.Shuffle(_random); // TODO investigate if thise matters
-                                                    // logItem("\n## All Magic Replacement.");
-                                                    // logReplacementDictionaryMagic(magicShopReplacement);
-
-        // logItem("\n~* Shop Magic Replacement.");
-        foreach (Param.Row row in _shopLineupParam.Rows)
-        {
-            // logShopIdMagic(row.ID);
-            if ((byte)row["equipType"]!.Value.Value != Const.ShopLineupGoodsCategory || row.ID > 101980)
-            { continue; }
-
-            ShopLineupParam lot = new(row);
-            if (!_magicDictionary.TryGetValue(lot.equipId, out _)) { continue; }
-
-            if (row.ID < 101950)
-            { replaceShopLineupParamMagic(lot, magicShopReplacement, shopLineupParamRemembranceList); }
-
-            else
-            {
-                ShopLineupParam newDragonIncant = getNewId(lot.equipId, shopLineupParamDragonList);
-                // logItem($"{_goodsFmg[lot.equipId]} -> {_goodsFmg[newDragonIncant.equipId]}");
-                copyShopLineupParam(lot, newDragonIncant);
-            }
-        }
-
-        foreach (Param.Row row in _itemLotParam_enemy.Rows.Concat(_itemLotParam_map.Rows))
-        {
-            Param.Column[] itemIds = row.Cells.Take(Const.ItemLots).ToArray();
-            Param.Column[] categories = row.Cells.Skip(Const.CategoriesStart).Take(Const.ItemLots).ToArray();
-            for (int i = 0; i < Const.ItemLots; i++)
-            {
-                int category = (int)categories[i].GetValue(row);
-                if (category != Const.ItemLotGoodsCategory) { continue; }
-
-                int id = (int)itemIds[i].GetValue(row);
-                if (!_magicDictionary.TryGetValue(id, out Magic _)) { continue; }
-
-                if (!magicShopReplacement.TryGetValue(id, out int entry)) { continue; }
-
-                itemIds[i].SetValue(row, entry);
             }
         }
     }


### PR DESCRIPTION
Set up logic to allow for starting classes to be separate from merchants
- allows for easier control over merchant allocations
- merchants now have logic to prevent duplicates