### PR TITLE
Bugfix: Custom Weapons

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ This application has a simple UI to ensure that all players use the same randomi
 
 # Weapon Type Pooling
 * Great Katanas are pooled with Katanas
+* Light Greatswords are pooled with Greatswords
+* Hand to Hand Arts are grouped with Fists
+* Beast Claws are grouped with Claws
+* Backhand Blades are grouped with Daggers
 * Ranged weapons are in grouped categories (bows & light bows, greatbows & ballistas are all in the same pool). 
 
 # Starting Classes

--- a/src/ERBingoRandomizer/FileHandler/BHD5Reader.cs
+++ b/src/ERBingoRandomizer/FileHandler/BHD5Reader.cs
@@ -14,22 +14,20 @@ public class BHD5Reader
     const uint FileCount = 5;
     private const string DataDLC = "DLC"; // TODO get file name
     private const string Data0 = "Data0";
-    //> unused for project
-    // private const string Data1 = "Data1";
-    // private const string Data2 = "Data2";
-    // private const string Data3 = "Data3";
-    // private static readonly string Data1CachePath = $"{Config.CachePath}/{Data1}";
-    // private static readonly string Data2CachePath = $"{Config.CachePath}/{Data2}";
-    // private static readonly string Data3CachePath = $"{Config.CachePath}/{Data3}";
-    // private readonly BHDInfo _data1;
-    // private readonly BHDInfo _data2;
-    // private readonly BHDInfo _data3;
-    //^ unused for project
+    private const string Data1 = "Data1";
+    private const string Data2 = "Data2";
+    private const string Data3 = "Data3";
     private static readonly string DlcCachePath = $"{Config.CachePath}/{DataDLC}";
     private static readonly string Data0CachePath = $"{Config.CachePath}/{Data0}";
+    private static readonly string Data1CachePath = $"{Config.CachePath}/{Data1}";
+    private static readonly string Data2CachePath = $"{Config.CachePath}/{Data2}";
+    private static readonly string Data3CachePath = $"{Config.CachePath}/{Data3}";
 
     private readonly BHDInfo _dataDLC;
-    private readonly BHDInfo _data0; // TODO where is this used
+    private readonly BHDInfo _data0;
+    private readonly BHDInfo _data1;
+    private readonly BHDInfo _data2;
+    private readonly BHDInfo _data3;
 
     public BHD5Reader(string path, bool cache, CancellationToken cancellationToken)
     {
@@ -80,8 +78,7 @@ public class BHD5Reader
         using MemoryStream fs = new(bytes);
         return BHD5.Read(fs, BHD5.Game.EldenRing);
     }
-    // Right now just works for data0 (needed basegame files)
-    // Need to add DLC gear    
+    // Right now just works for data0 (needed basegame files)   
     public byte[]? GetFile(string filePath)
     {
         ulong hash = Util.ComputeHash(filePath, BHD5.Game.EldenRing);
@@ -97,7 +94,6 @@ public class BHD5Reader
             Debug.WriteLine($"{filePath} DLC01: {(_dataDLC.GetSalt)}");
             return file;
         }
-
         // file = _data1.GetFile(hash);
         // if (file != null) {
         //     Debug.WriteLine($"{filePath} Data1: {_data1.GetSalt()}");

--- a/src/ERBingoRandomizer/Settings/Const.cs
+++ b/src/ERBingoRandomizer/Settings/Const.cs
@@ -104,6 +104,7 @@ public static class Const
     // Item Lot constants 
     public const int ItemLotGoodsCategory = 1;
     public const int ItemLotWeaponCategory = 2;
+    public const int ItemLotArmorCategory = 3;
     public const int ItemLotCustomWeaponCategory = 6;
     // Shop Lineup constants
     public const byte ShopLineupWeaponCategory = 0;

--- a/src/ERBingoRandomizer/Tasks/Randomizer.Init.cs
+++ b/src/ERBingoRandomizer/Tasks/Randomizer.Init.cs
@@ -170,6 +170,9 @@ public partial class Randomizer
             _weaponNameDictionary[row.ID] = $"{_weaponNameDictionary[customWep.baseWepId]} +{customWep.reinforceLv}";
             _customWeaponDictionary.Add(row.ID, wep);
         }
+        // workarounds TODO update to not need
+        _weaponNameDictionary[16010007] = "Spear + 7";
+        _weaponDictionary[16010007] = _weaponDictionary[16010000];
         //^ end of weapon dictionary building
 
         _armorTypeDictionary = new Dictionary<byte, List<Param.Row>>();


### PR DESCRIPTION
A few weeks ago, I bug-fixed Sword of Light and Darkness. Adjusted logic for Custom Weapons at the time.

This created a bug, that has now been reverted.

Update new groupings:
* Light Greatswords are pooled with Greatswords
* Hand to Hand Arts are grouped with Fists
* Beast Claws are grouped with Claws
* Backhand Blades are grouped with Daggers